### PR TITLE
Phase 31: Agent Engine Promotion Strategy (Dev -> Stage -> Prod)

### DIFF
--- a/000-docs/187-AA-PLAN-phase-31-agent-engine-promotion-strategy.md
+++ b/000-docs/187-AA-PLAN-phase-31-agent-engine-promotion-strategy.md
@@ -1,0 +1,58 @@
+# Phase 31: Agent Engine Promotion Strategy
+
+**Date:** 2025-12-11
+**Status:** In Progress
+**Branch:** `feature/phase-31-agent-engine-promotion-strategy`
+
+## Objective
+
+Define a promotion pattern for ReasoningEngines (dev -> stage -> prod) using config and documentation only. No actual deployments or API calls.
+
+## Desired Flow
+
+```
+Dev Agent Engine (validated)
+    |
+    v  [Promotion Script - config only]
+Stage Agent Engine (validated)
+    |
+    v  [Promotion Script - config only]
+Prod Agent Engine (deployed via Terraform/CI)
+```
+
+## Non-Goals
+
+- Modify or delete any existing Agent Engine instances
+- Add gcloud commands
+- Actually perform promotions in GCP
+- Change runtime architecture
+
+## Deliverables
+
+1. **Agent Engine Environment Mapping**
+   - `config/agent_engine_envs.yaml` - Maps agents to engine IDs per environment
+   - Clear TODO placeholders for unknown IDs
+
+2. **Promotion Helper Script**
+   - `scripts/promote_agent_engine_config.py`
+   - Reads config, shows mapping/diff
+   - No API calls - config validation only
+
+3. **Make Targets**
+   - `promote-agent-config-dev-to-stage`
+   - `promote-agent-config-stage-to-prod`
+
+4. **Operator Documentation**
+   - Agent Engine promotion playbook
+   - CLAUDE.md updates
+
+## Implementation Steps
+
+1. Create `config/agent_engine_envs.yaml` with mapping structure
+2. Create promotion helper script (config-only, no API)
+3. Add Make targets for promotion workflow
+4. Update CLAUDE.md with promotion section
+5. Create promotion playbook runbook
+
+---
+**Last Updated:** 2025-12-11

--- a/000-docs/188-RB-OPER-agent-engine-promotion-playbook.md
+++ b/000-docs/188-RB-OPER-agent-engine-promotion-playbook.md
@@ -1,0 +1,150 @@
+# Agent Engine Promotion Playbook
+
+**Date:** 2025-12-11
+**Status:** Active
+**Type:** Runbook (Operator Guide)
+
+## Overview
+
+This playbook describes the process for promoting Agent Engine deployments from dev -> stage -> prod.
+
+## Promotion Flow
+
+```
+DEV (Development)
+  |
+  | [Validated via ARV gates]
+  v
+STAGE (Pre-Production)
+  |
+  | [Validated + Manual Approval]
+  v
+PROD (Production)
+```
+
+## Pre-Promotion Checklist
+
+### Dev -> Stage
+
+Before promoting from dev to stage:
+
+- [ ] Unit tests passing (`make test`)
+- [ ] A2A contract validation passing (`make check-a2a-contracts`)
+- [ ] ARV department checks passing (`make arv-department`)
+- [ ] Drift detection clean (`make check-all`)
+- [ ] Dev smoke tests passing
+- [ ] Engine IDs configured in `config/agent_engine_envs.yaml`
+
+### Stage -> Prod
+
+Before promoting from stage to prod:
+
+- [ ] All dev -> stage checks passing
+- [ ] Stage smoke tests passing
+- [ ] Stage health check OK
+- [ ] Manual approval obtained (#deployments channel)
+- [ ] Engine IDs configured for prod
+
+## Commands
+
+### View Current Mapping
+
+```bash
+# Show all agent mappings
+make promote-agent-config-show
+
+# Or directly:
+python scripts/promote_agent_engine_config.py --agent all
+```
+
+### View Promotion Path
+
+```bash
+# Dev to Stage
+make promote-agent-config-dev-to-stage
+
+# Stage to Prod
+make promote-agent-config-stage-to-prod
+```
+
+### Validate Promotion Readiness
+
+```bash
+# Validate dev -> stage (exits 2 if TODOs remain)
+make promote-agent-config-validate-dev-to-stage
+
+# Validate stage -> prod
+make promote-agent-config-validate-stage-to-prod
+```
+
+## Configuration Updates
+
+### After Deploying to an Environment
+
+1. Get the Engine ID from deployment output or Vertex AI Console
+2. Update `config/agent_engine_envs.yaml`:
+   ```yaml
+   agents:
+     bob:
+       environments:
+         dev:
+           engine_id: "projects/123/locations/us-central1/agents/abc123"
+           status: "deployed"
+   ```
+3. Commit the change:
+   ```bash
+   git add config/agent_engine_envs.yaml
+   git commit -m "config: update bob dev engine ID after deployment"
+   ```
+
+### Finding Engine IDs
+
+**From Deployment Output:**
+```
+Agent deployed successfully!
+Engine ID: projects/bobs-brain-dev/locations/us-central1/agents/abc123def456
+```
+
+**From Vertex AI Console:**
+1. Go to Vertex AI > Agent Engine
+2. Find your agent
+3. Copy the full resource name
+
+## Monitoring After Promotion
+
+### Dev Environment
+
+- Check Cloud Run logs
+- Verify agent responds to test queries
+- Monitor for errors in first hour
+
+### Stage Environment
+
+- Full smoke test suite
+- Load testing if applicable
+- Integration tests with external services
+
+### Prod Environment
+
+- Gradual rollout if supported
+- Active monitoring for first 24 hours
+- Rollback plan ready
+
+## Rollback Procedure
+
+If issues are discovered after promotion:
+
+1. **Immediate:** Route traffic back to previous version
+2. **Investigate:** Check logs, identify root cause
+3. **Fix:** Update code, test in dev
+4. **Re-promote:** Follow standard promotion flow
+
+## Related Documentation
+
+- Phase 31 Plan: `000-docs/187-AA-PLAN-phase-31-agent-engine-promotion-strategy.md`
+- Deploy Script: `scripts/deploy_inline_source.py`
+- Config File: `config/agent_engine_envs.yaml`
+- ARV Checks: `scripts/check_inline_deploy_ready.py`
+
+---
+**Last Updated:** 2025-12-11

--- a/000-docs/189-AA-REPT-phase-31-agent-engine-promotion-strategy.md
+++ b/000-docs/189-AA-REPT-phase-31-agent-engine-promotion-strategy.md
@@ -1,0 +1,97 @@
+# Phase 31: Agent Engine Promotion Strategy - AAR
+
+**Date:** 2025-12-11
+**Status:** Complete
+**Branch:** `feature/phase-31-agent-engine-promotion-strategy`
+
+## Summary
+
+Defined Agent Engine promotion strategy (dev -> stage -> prod) with config-only tooling. No actual API calls or deployments - pure config and documentation.
+
+## What Was Built
+
+### 1. Agent Engine Environment Mapping
+
+**File:** `config/agent_engine_envs.yaml`
+
+- YAML config mapping agents to engine IDs per environment
+- Structured with:
+  - Agent metadata (name, description, directory)
+  - Environment configs (project, region, engine ID, status)
+  - Promotion requirements per stage
+- All engine IDs use TODO placeholders (to be filled after actual deploys)
+- Schema version tracking for future migrations
+
+### 2. Promotion Helper Script
+
+**File:** `scripts/promote_agent_engine_config.py`
+
+Features:
+- Show all agent mappings (`--agent all`)
+- Show promotion path (`--from-env dev --to-env stage`)
+- Validate promotion readiness (`--validate`, exits 2 if TODOs remain)
+- No API calls - pure config validation
+
+### 3. Make Targets
+
+Added to Makefile:
+- `promote-agent-config-show` - View all mappings
+- `promote-agent-config-dev-to-stage` - Dev to stage path
+- `promote-agent-config-stage-to-prod` - Stage to prod path
+- `promote-agent-config-validate-dev-to-stage` - Validate readiness
+- `promote-agent-config-validate-stage-to-prod` - Validate readiness
+
+### 4. Operator Documentation
+
+**File:** `000-docs/188-RB-OPER-agent-engine-promotion-playbook.md`
+
+- Pre-promotion checklists
+- Command reference
+- Configuration update procedure
+- Monitoring guidance
+- Rollback procedure
+
+### 5. CLAUDE.md Updates
+
+Added "Agent Engine Promotion (Phase 31)" section with:
+- Promotion flow description
+- Config file reference
+- Key make commands
+- Playbook link
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `000-docs/187-AA-PLAN-phase-31-agent-engine-promotion-strategy.md` | Created |
+| `000-docs/188-RB-OPER-agent-engine-promotion-playbook.md` | Created |
+| `000-docs/189-AA-REPT-phase-31-agent-engine-promotion-strategy.md` | Created |
+| `config/agent_engine_envs.yaml` | Created |
+| `scripts/promote_agent_engine_config.py` | Created |
+| `Makefile` | Updated (added promotion targets) |
+| `CLAUDE.md` | Updated (added promotion section) |
+
+## Validation
+
+```
+$ python scripts/promote_agent_engine_config.py --agent all
+Config Version: 1.0.0
+App Version: 0.14.1
+
+Agent: bob - all envs show TODO placeholders
+Agent: foreman - all envs show TODO placeholders
+```
+
+Expected: All TODOs present (no deployments yet)
+
+## Next Steps
+
+1. After dev deployment:
+   - Get engine ID from deployment output
+   - Update config/agent_engine_envs.yaml
+   - Run `make promote-agent-config-validate-dev-to-stage`
+
+2. Phase 32 will harden repo as reference template
+
+---
+**Last Updated:** 2025-12-11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,15 @@ This is the **live** guide for Claude Code when working in the `bobs-brain` repo
 - ⛔ **NEVER run**: `gcloud run services update slack-webhook` (manual deploys violate R4)
 - 📖 **Operator Guide**: `000-docs/164-AA-REPT-phase-24-slack-bob-ci-deploy-and-restore.md`
 
+**Agent Engine Promotion (Phase 31):**
+- **Flow**: dev (validated) -> stage (validated) -> prod (deployed)
+- **Config**: `config/agent_engine_envs.yaml` - Maps agents to engine IDs per environment
+- **Commands**:
+  - `make promote-agent-config-show` - View all agent mappings
+  - `make promote-agent-config-dev-to-stage` - Show dev->stage path
+  - `make promote-agent-config-validate-dev-to-stage` - Validate promotion readiness
+- 📖 **Playbook**: `000-docs/188-RB-OPER-agent-engine-promotion-playbook.md`
+
 ---
 
 ## 2. Repo Context & Architecture

--- a/Makefile
+++ b/Makefile
@@ -687,6 +687,35 @@ deploy-help: ## Show deployment help and requirements
 	@echo "  SLACK_SIGNING_SECRET"
 	@echo "  SLACK_BOT_TOKEN"
 
+## ============================================================================
+## Agent Engine Promotion (Phase 31) - Config-only promotion workflow
+## ============================================================================
+
+promote-agent-config-show: ## Show all agent engine environment mappings
+	@echo "$(BLUE)📋 Agent Engine Environment Mappings$(NC)"
+	@$(PYTHON) scripts/promote_agent_engine_config.py --agent all
+	@echo ""
+
+promote-agent-config-dev-to-stage: ## Show dev -> stage promotion path for all agents
+	@echo "$(BLUE)🔄 Promotion Path: dev -> stage$(NC)"
+	@$(PYTHON) scripts/promote_agent_engine_config.py --from-env dev --to-env stage --agent all
+	@echo ""
+
+promote-agent-config-stage-to-prod: ## Show stage -> prod promotion path for all agents
+	@echo "$(BLUE)🔄 Promotion Path: stage -> prod$(NC)"
+	@$(PYTHON) scripts/promote_agent_engine_config.py --from-env stage --to-env prod --agent all
+	@echo ""
+
+promote-agent-config-validate-dev-to-stage: ## Validate dev -> stage promotion readiness
+	@echo "$(BLUE)✅ Validating dev -> stage promotion...$(NC)"
+	@$(PYTHON) scripts/promote_agent_engine_config.py --from-env dev --to-env stage --agent all --validate
+	@echo ""
+
+promote-agent-config-validate-stage-to-prod: ## Validate stage -> prod promotion readiness
+	@echo "$(BLUE)✅ Validating stage -> prod promotion...$(NC)"
+	@$(PYTHON) scripts/promote_agent_engine_config.py --from-env stage --to-env prod --agent all --validate
+	@echo ""
+
 .PHONY: help setup test lint format clean docker version benchmark ci all
 .PHONY: install-hooks deps format-check type-check
 .PHONY: test-v1 test-v2 test-coverage
@@ -701,3 +730,5 @@ deploy-help: ## Show deployment help and requirements
 .PHONY: live3-dev-smoke live3-dev-smoke-verbose live3-dev-smoke-all
 .PHONY: slack-dev-smoke slack-dev-smoke-verbose slack-dev-smoke-health slack-dev-smoke-cloud
 .PHONY: deploy-dev deploy-staging deploy-prod deploy-status deploy-logs deploy-list deploy-help
+.PHONY: promote-agent-config-show promote-agent-config-dev-to-stage promote-agent-config-stage-to-prod
+.PHONY: promote-agent-config-validate-dev-to-stage promote-agent-config-validate-stage-to-prod

--- a/config/agent_engine_envs.yaml
+++ b/config/agent_engine_envs.yaml
@@ -1,0 +1,106 @@
+# Agent Engine Environment Mapping
+#
+# Maps each agent to its ReasoningEngine ID per environment.
+# Used by: scripts/promote_agent_engine_config.py
+#
+# Promotion Flow:
+#   dev (validated) -> stage (validated) -> prod (deployed)
+#
+# To update after deployment:
+#   1. Deploy agent to environment
+#   2. Get engine ID from Vertex AI Console or deployment output
+#   3. Update this file with the actual ID
+#   4. Commit change to repo
+#
+# TODO placeholders: Search for "TODO-SET-" to find values that need updating
+
+# Version info
+schema_version: "1.0.0"
+last_updated: "2025-12-11"
+app_version: "0.14.1"
+
+# Agent configurations
+agents:
+  # Bob - Main orchestrator agent
+  bob:
+    display_name: "Bob's Brain"
+    description: "Global orchestrator for the ADK compliance department"
+    agent_dir: "agents/bob"
+    environments:
+      dev:
+        project_id: "bobs-brain-dev"
+        region: "us-central1"
+        engine_id: "TODO-SET-DEV-ENGINE-ID"
+        engine_name: "bobs-brain-dev"
+        status: "pending"  # pending | deployed | validated
+      stage:
+        project_id: "bobs-brain-stage"
+        region: "us-central1"
+        engine_id: "TODO-SET-STAGE-ENGINE-ID"
+        engine_name: "bobs-brain-stage"
+        status: "pending"
+      prod:
+        project_id: "bobs-brain"
+        region: "us-central1"
+        engine_id: "TODO-SET-PROD-ENGINE-ID"
+        engine_name: "bobs-brain-prod"
+        status: "pending"
+
+  # Foreman - IAM Senior ADK DevOps Lead
+  foreman:
+    display_name: "IAM Senior ADK DevOps Lead"
+    description: "Workflow orchestrator for the IAM department"
+    agent_dir: "agents/iam-senior-adk-devops-lead"
+    environments:
+      dev:
+        project_id: "bobs-brain-dev"
+        region: "us-central1"
+        engine_id: "TODO-SET-DEV-ENGINE-ID"
+        engine_name: "iam-foreman-dev"
+        status: "pending"
+      stage:
+        project_id: "bobs-brain-stage"
+        region: "us-central1"
+        engine_id: "TODO-SET-STAGE-ENGINE-ID"
+        engine_name: "iam-foreman-stage"
+        status: "pending"
+      prod:
+        project_id: "bobs-brain"
+        region: "us-central1"
+        engine_id: "TODO-SET-PROD-ENGINE-ID"
+        engine_name: "iam-foreman-prod"
+        status: "pending"
+
+# Promotion requirements
+promotion:
+  dev_to_stage:
+    required_checks:
+      - "Unit tests passing"
+      - "A2A contract validation"
+      - "ARV department checks"
+      - "Drift detection clean"
+    manual_approval: false
+
+  stage_to_prod:
+    required_checks:
+      - "All dev_to_stage checks"
+      - "Stage smoke tests passing"
+      - "Stage health check OK"
+    manual_approval: true
+    approval_channel: "#deployments"
+
+# Environment metadata
+environments:
+  dev:
+    purpose: "Development and testing"
+    auto_deploy: true
+    monitoring: "basic"
+  stage:
+    purpose: "Pre-production validation"
+    auto_deploy: false
+    monitoring: "enhanced"
+  prod:
+    purpose: "Production workloads"
+    auto_deploy: false
+    monitoring: "full"
+    alerting: true

--- a/scripts/promote_agent_engine_config.py
+++ b/scripts/promote_agent_engine_config.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Agent Engine Promotion Config Helper
+
+Shows the current Agent Engine environment mapping and validates
+configuration readiness for promotion. Does NOT make any API calls
+or deploy anything - config validation only.
+
+Usage:
+    # Show all agent mappings
+    python scripts/promote_agent_engine_config.py --agent all
+
+    # Show specific agent promotion path
+    python scripts/promote_agent_engine_config.py --from-env dev --to-env stage --agent bob
+
+    # Validate promotion readiness
+    python scripts/promote_agent_engine_config.py --from-env stage --to-env prod --agent all --validate
+
+Exit Codes:
+    0 - Success (config valid or shown)
+    1 - Config file error
+    2 - Validation failed (TODOs remain)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# Config file path
+CONFIG_FILE = Path(__file__).parent.parent / "config" / "agent_engine_envs.yaml"
+
+
+def load_config() -> dict:
+    """Load agent engine environment config."""
+    if not CONFIG_FILE.exists():
+        print(f"ERROR: Config file not found: {CONFIG_FILE}")
+        sys.exit(1)
+
+    with open(CONFIG_FILE) as f:
+        return yaml.safe_load(f)
+
+
+def show_agent_mapping(config: dict, agent_name: str) -> None:
+    """Display environment mapping for an agent."""
+    agents = config.get("agents", {})
+
+    if agent_name not in agents:
+        print(f"ERROR: Agent '{agent_name}' not found in config")
+        print(f"Available agents: {', '.join(agents.keys())}")
+        sys.exit(1)
+
+    agent = agents[agent_name]
+    print(f"\n{'='*60}")
+    print(f"Agent: {agent_name}")
+    print(f"Display Name: {agent.get('display_name', 'N/A')}")
+    print(f"Directory: {agent.get('agent_dir', 'N/A')}")
+    print(f"{'='*60}")
+
+    envs = agent.get("environments", {})
+    for env_name in ["dev", "stage", "prod"]:
+        if env_name in envs:
+            env = envs[env_name]
+            engine_id = env.get("engine_id", "NOT SET")
+            status = env.get("status", "unknown")
+            project = env.get("project_id", "N/A")
+
+            # Mark TODOs
+            is_todo = "TODO" in str(engine_id)
+            status_icon = "[ ]" if is_todo else "[x]"
+
+            print(f"\n  {env_name.upper()}")
+            print(f"    {status_icon} Engine ID: {engine_id}")
+            print(f"        Project: {project}")
+            print(f"        Status: {status}")
+
+
+def show_promotion_path(
+    config: dict, from_env: str, to_env: str, agent_name: str
+) -> int:
+    """Show promotion path from one env to another."""
+    agents = config.get("agents", {})
+    todo_count = 0
+
+    print(f"\n{'='*60}")
+    print(f"PROMOTION PATH: {from_env.upper()} -> {to_env.upper()}")
+    print(f"{'='*60}")
+
+    agent_list = list(agents.keys()) if agent_name == "all" else [agent_name]
+
+    for name in agent_list:
+        if name not in agents:
+            print(f"WARNING: Agent '{name}' not found, skipping")
+            continue
+
+        agent = agents[name]
+        envs = agent.get("environments", {})
+
+        from_config = envs.get(from_env, {})
+        to_config = envs.get(to_env, {})
+
+        from_id = from_config.get("engine_id", "NOT SET")
+        to_id = to_config.get("engine_id", "NOT SET")
+
+        from_todo = "TODO" in str(from_id)
+        to_todo = "TODO" in str(to_id)
+
+        if from_todo:
+            todo_count += 1
+        if to_todo:
+            todo_count += 1
+
+        print(f"\n  {name}:")
+        print(f"    {from_env}: {from_id} {'(TODO)' if from_todo else ''}")
+        print(f"    {to_env}:   {to_id} {'(TODO)' if to_todo else ''}")
+
+    # Show promotion requirements
+    promo_key = f"{from_env}_to_{to_env}"
+    promo_config = config.get("promotion", {}).get(promo_key, {})
+
+    if promo_config:
+        print(f"\n  Required Checks:")
+        for check in promo_config.get("required_checks", []):
+            print(f"    - {check}")
+
+        if promo_config.get("manual_approval"):
+            channel = promo_config.get("approval_channel", "#general")
+            print(f"\n  Manual Approval Required: Yes ({channel})")
+
+    return todo_count
+
+
+def validate_promotion(
+    config: dict, from_env: str, to_env: str, agent_name: str
+) -> bool:
+    """Validate that promotion config is complete (no TODOs)."""
+    todo_count = show_promotion_path(config, from_env, to_env, agent_name)
+
+    print(f"\n{'='*60}")
+    if todo_count == 0:
+        print("VALIDATION: PASS - All engine IDs configured")
+        return True
+    else:
+        print(f"VALIDATION: FAIL - {todo_count} TODO(s) remaining")
+        print("\nTo fix:")
+        print("  1. Deploy agents to environments")
+        print("  2. Get engine IDs from deployment output")
+        print("  3. Update config/agent_engine_envs.yaml")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Agent Engine Promotion Config Helper"
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent name (bob, foreman) or 'all'",
+    )
+    parser.add_argument(
+        "--from-env",
+        choices=["dev", "stage", "prod"],
+        help="Source environment",
+    )
+    parser.add_argument(
+        "--to-env",
+        choices=["dev", "stage", "prod"],
+        help="Target environment",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate promotion readiness (exit 2 if TODOs remain)",
+    )
+
+    args = parser.parse_args()
+
+    config = load_config()
+
+    # Show schema version
+    print(f"Config Version: {config.get('schema_version', 'unknown')}")
+    print(f"App Version: {config.get('app_version', 'unknown')}")
+
+    # If from/to specified, show promotion path
+    if args.from_env and args.to_env:
+        if args.validate:
+            valid = validate_promotion(config, args.from_env, args.to_env, args.agent)
+            sys.exit(0 if valid else 2)
+        else:
+            show_promotion_path(config, args.from_env, args.to_env, args.agent)
+    else:
+        # Just show agent mapping
+        if args.agent == "all":
+            for agent_name in config.get("agents", {}).keys():
+                show_agent_mapping(config, agent_name)
+        else:
+            show_agent_mapping(config, args.agent)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Defines Agent Engine promotion strategy with config-only tooling. No live infra changes.

**Changes:**
- Created `config/agent_engine_envs.yaml` - Maps agents to engine IDs per environment
- Created `scripts/promote_agent_engine_config.py` - Promotion helper (no API calls)
- Added Make targets for promotion workflow
- Created promotion playbook runbook
- Updated CLAUDE.md with promotion section

**No actual deployments or API calls** - config + docs only.

## Test Plan
- [x] Promotion script runs successfully
- [x] Shows TODO placeholders for all environments
- [x] Validate mode exits 2 when TODOs remain (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)