### PR TITLE
Phase 32: Reference Template Hardening

### DIFF
--- a/000-docs/190-AA-PLAN-phase-32-reference-template-hardening.md
+++ b/000-docs/190-AA-PLAN-phase-32-reference-template-hardening.md
@@ -1,0 +1,45 @@
+# Phase 32: Reference Template Hardening
+
+**Date:** 2025-12-11
+**Status:** In Progress
+**Branch:** `feature/phase-32-reference-template-hardening`
+
+## Objective
+
+Make bobs-brain explicitly usable as a reference/template for future IAM/agent repos. Harden documentation so new teams can follow the pattern independently.
+
+## Non-Goals
+
+- Renaming the repository
+- Changing runtime architecture
+- Modifying agent behavior
+
+## Deliverables
+
+1. **Flat Index of Key Documents**
+   - `000-docs/191-INDEX-bobs-brain-reference-map.md`
+   - Sections: Phases & AARs, Standards, Runbooks, Infrastructure
+
+2. **New Engineer Quickstart**
+   - `000-docs/192-OVERVIEW-new-engineer-quickstart.md`
+   - Repo purpose, architecture, first commands
+
+3. **CLAUDE.md Template Instructions**
+   - "Using bobs-brain as a Template" section
+   - Steps for new repos
+   - "Do not do this" list
+
+4. **Cleanup Verification**
+   - Confirm 000-docs/ stays flat (no nested dirs)
+   - Mark any legacy docs in INDEX
+
+## Implementation Steps
+
+1. Create reference map index
+2. Create new engineer quickstart
+3. Update CLAUDE.md with template instructions
+4. Verify 000-docs/ structure
+5. Create AAR
+
+---
+**Last Updated:** 2025-12-11

--- a/000-docs/191-INDEX-bobs-brain-reference-map.md
+++ b/000-docs/191-INDEX-bobs-brain-reference-map.md
@@ -1,0 +1,161 @@
+# Bob's Brain Reference Map
+
+**Date:** 2025-12-11
+**Purpose:** Master index for navigating bobs-brain as a reference/template repository
+
+## Quick Navigation
+
+| Need To... | Go To |
+|------------|-------|
+| Understand the architecture | [Architecture Section](#architecture) |
+| Deploy agents | [Deployment Section](#deployment) |
+| Add new agents | [Agent Development Section](#agent-development) |
+| Check compliance | [Standards Section](#standards-6767-series) |
+| Onboard new engineer | [New Engineer Quickstart](192-OVERVIEW-new-engineer-quickstart.md) |
+
+---
+
+## Phases & AARs
+
+Recent phases (reverse chronological):
+
+| Phase | Doc ID | Description |
+|-------|--------|-------------|
+| 32 | 190-192 | Reference Template Hardening |
+| 31 | 187-189 | Agent Engine Promotion Strategy |
+| 30 | 185-186 | Stage Environment Baseline |
+| 27 | 183-184 | Deployment Validation |
+| 26 | 181-182 | Repository Cleanup & Release |
+| 25 | (PR focused) | Slack Bob Hardening |
+| 24 | 164-165 | Slack Bob CI Deploy & Restore |
+| 23 | 155-157 | Inline Deploy Implementation |
+| 21-22 | 150-154 | Agent Engine Dev Wiring |
+
+Full phase history: See doc range 050-184 for all phase AARs.
+
+---
+
+## Standards (6767 Series)
+
+**Master Catalog:** `6767-DR-INDEX-bobs-brain-standards-catalog.md`
+
+### Core Standards
+
+| Doc | Title | Purpose |
+|-----|-------|---------|
+| `6767-DR-STND-adk-agent-engine-spec-and-hardmode-rules.md` | Hard Mode Rules (R1-R8) | Architectural constraints |
+| `6767-LAZY-DR-STND-adk-lazy-loading-app-pattern.md` | Lazy Loading Pattern | Agent initialization |
+| `6767-INLINE-DR-STND-inline-source-deployment-for-vertex-agent-engine.md` | Inline Deployment | Deploy without serialization |
+| `6767-DR-STND-agentcards-and-a2a-contracts.md` | AgentCards & A2A | Inter-agent communication |
+| `6767-DR-STND-document-filing-system-standard-v3.md` | Doc Filing System | How to name docs |
+
+### Deployment Standards
+
+| Doc | Title | Purpose |
+|-----|-------|---------|
+| `6767-DR-INDEX-agent-engine-a2a-inline-deploy.md` | Deployment Sub-Index | All deployment docs |
+| `6767-DR-STND-slack-gateway-deploy-pattern.md` | Slack Gateway | Cloud Run proxy pattern |
+| `6767-DR-STND-arv-minimum-gate.md` | ARV Gates | Deployment readiness checks |
+
+---
+
+## Runbooks
+
+| Doc | Title | Use Case |
+|-----|-------|----------|
+| `6767-RB-OPS-adk-department-operations-runbook.md` | Operations Runbook | Day-to-day ops |
+| `188-RB-OPER-agent-engine-promotion-playbook.md` | Promotion Playbook | Dev -> Stage -> Prod |
+| `6767-SLKDEV-DR-GUIDE-slack-dev-integration-operator-guide.md` | Slack Integration | Slack setup |
+| `070-OD-RBOK-deployment-runbook.md` | General Deployment | Legacy deployment guide |
+
+---
+
+## Architecture
+
+| Doc | Title | Purpose |
+|-----|-------|---------|
+| `082-AT-ARCH-department-complete-structure.md` | Department Structure | Full org chart |
+| `094-AT-ARCH-iam-swe-pipeline-orchestration.md` | SWE Pipeline | Workflow orchestration |
+| `101-AT-ARCH-agent-engine-topology-and-envs.md` | Engine Topology | Environment layout |
+| `102-AT-ARCH-cloud-run-gateways-and-agent-engine-routing.md` | Gateway Routing | A2A routing |
+
+---
+
+## Infrastructure
+
+### Terraform
+
+| Path | Purpose |
+|------|---------|
+| `infra/terraform/envs/dev.tfvars` | Dev environment config |
+| `infra/terraform/envs/stage.tfvars` | Stage environment config |
+| `infra/terraform/envs/prod.tfvars` | Production config |
+| `infra/terraform/modules/` | Reusable TF modules |
+
+### CI Workflows
+
+| Workflow | Purpose |
+|----------|---------|
+| `.github/workflows/ci.yml` | Main CI (lint, test, checks) |
+| `.github/workflows/terraform-prod.yml` | Production Terraform (R4) |
+| `.github/workflows/terraform-stage.yml` | Stage Terraform (plan-only) |
+| `.github/workflows/a2a-compliance.yml` | A2A contract validation |
+
+---
+
+## Agent Development
+
+### Key Files Per Agent
+
+```
+agents/<agent-name>/
+  ├── agent.py           # Agent definition (LlmAgent)
+  ├── app.py             # Lazy-loading App pattern
+  ├── a2a_card.py        # AgentCard definition
+  ├── tools/             # Agent-specific tools
+  └── .well-known/
+      └── agent-card.json  # Published AgentCard
+```
+
+### Shared Components
+
+| Path | Purpose |
+|------|---------|
+| `agents/shared_contracts.py` | Pydantic models for all agents |
+| `agents/a2a/types.py` | A2A protocol types |
+| `agents/config/` | Shared configuration |
+
+---
+
+## Config Files
+
+| File | Purpose |
+|------|---------|
+| `config/agent_engine_envs.yaml` | Engine ID mapping per env |
+| `config/repos.yaml` | Target repos for SWE pipeline |
+| `VERSION` | Current version |
+| `CLAUDE.md` | AI assistant guidance |
+
+---
+
+## Legacy / Reference Directories
+
+These subdirectories exist for reference but are not part of active development:
+
+| Directory | Purpose |
+|-----------|---------|
+| `000-docs/001-usermanual/` | ADK reference notebooks |
+| `000-docs/google-reference/` | Symlink to local ADK docs |
+
+**Note:** Per R6, all new docs should be flat files in `000-docs/`, not in subdirectories.
+
+---
+
+## See Also
+
+- [New Engineer Quickstart](192-OVERVIEW-new-engineer-quickstart.md)
+- [CLAUDE.md](../CLAUDE.md) - AI assistant guidance
+- [README.md](../README.md) - Repository overview
+
+---
+**Last Updated:** 2025-12-11

--- a/000-docs/192-OVERVIEW-new-engineer-quickstart.md
+++ b/000-docs/192-OVERVIEW-new-engineer-quickstart.md
@@ -1,0 +1,154 @@
+# New Engineer Quickstart
+
+**Date:** 2025-12-11
+**Audience:** Engineers new to bobs-brain repository
+
+## What Is This Repo?
+
+**Bob's Brain** is a production-grade **ADK agent department** - a multi-agent system built on:
+- Google Agent Development Kit (ADK)
+- Vertex AI Agent Engine
+- Cloud Run gateways
+
+It serves as:
+1. A working Slack AI assistant
+2. The canonical reference implementation for multi-agent departments
+3. A template for future agent repositories
+
+## High-Level Architecture
+
+```
+User (Slack)
+    |
+    v
+Bob (Orchestrator LLM Agent)
+    |
+    v [A2A Protocol]
+Foreman (iam-senior-adk-devops-lead)
+    |
+    v [A2A Protocol]
+Specialists (iam-adk, iam-issue, iam-qa, etc.)
+```
+
+**Key Concepts:**
+- **Bob**: Conversational interface, delegates complex work
+- **Foreman**: Orchestrates workflows across specialists
+- **Specialists**: Execute specific tasks (compliance checks, issue creation, etc.)
+- **A2A Protocol**: Agent-to-agent communication via AgentCards
+
+## Repository Structure
+
+```
+bobs-brain/
+├── agents/              # ADK agent implementations
+│   ├── bob/             # Main orchestrator
+│   ├── iam-senior-adk-devops-lead/  # Foreman
+│   ├── iam_adk/         # ADK compliance specialist
+│   ├── iam_issue/       # Issue creation specialist
+│   └── shared_contracts.py  # Shared Pydantic models
+│
+├── service/             # Cloud Run gateways
+│   └── slack-webhook/   # Slack -> Bob gateway
+│
+├── infra/terraform/     # Infrastructure as Code
+│   ├── envs/            # dev, stage, prod configs
+│   └── modules/         # Reusable TF modules
+│
+├── scripts/             # Automation scripts
+│   ├── deploy_inline_source.py
+│   └── promote_agent_engine_config.py
+│
+├── tests/               # Unit and integration tests
+│
+├── config/              # Configuration files
+│   └── agent_engine_envs.yaml  # Engine ID mapping
+│
+├── 000-docs/            # ALL documentation (flat)
+│
+├── CLAUDE.md            # AI assistant guidance
+├── VERSION              # Current version
+└── Makefile             # Development commands
+```
+
+## First Commands
+
+After cloning, run these to verify your setup:
+
+```bash
+# 1. Create virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# 2. Run all quality checks
+make check-all
+
+# 3. Run unit tests
+make test
+
+# 4. Check A2A contracts
+make check-a2a-contracts
+
+# 5. Run ARV department checks
+make arv-department
+```
+
+## Where To Look First
+
+1. **CLAUDE.md** - AI assistant guidance, TL;DR section has quick reference
+2. **000-docs/191-INDEX-bobs-brain-reference-map.md** - Master doc index
+3. **000-docs/6767-DR-STND-adk-agent-engine-spec-and-hardmode-rules.md** - Hard Mode rules (R1-R8)
+
+## Key Rules (The "Don'ts")
+
+1. **Don't use gcloud CLI for deployments** - All deploys via Terraform/CI (R4)
+2. **Don't create nested folders in 000-docs/** - Keep flat (R6)
+3. **Don't import non-ADK frameworks** - No LangChain, CrewAI (R1)
+4. **Don't skip ARV gates** - Always validate before deploy
+5. **Don't edit secrets directly** - Use Secret Manager
+
+## Common Tasks
+
+### Add a New Agent
+
+1. Create directory: `agents/<agent-name>/`
+2. Add `agent.py`, `app.py`, `a2a_card.py`
+3. Add to `agents/__init__.py`
+4. Create AgentCard tests
+5. Run `make check-a2a-contracts`
+
+### Deploy to Dev
+
+```bash
+# Validate first
+make check-inline-deploy-ready
+
+# Dry run
+make deploy-inline-dry-run
+
+# Actual deploy (requires GCP auth)
+make deploy-inline-dev-execute
+```
+
+### Create Documentation
+
+1. Find next doc number: `ls 000-docs/*.md | tail -5`
+2. Use format: `NNN-CC-ABCD-description.md`
+3. Categories: AA (AAR), AT (Architecture), DR (Reference), RB (Runbook)
+
+## Getting Help
+
+- **Docs**: Check `000-docs/` index first
+- **Standards**: Search `000-docs/6767-*`
+- **CLAUDE.md**: Detailed guidance for AI assistants
+- **Slack**: #bobs-brain channel
+
+## Next Steps
+
+1. Read CLAUDE.md (especially TL;DR section)
+2. Explore `agents/bob/` to see agent structure
+3. Run `make help` to see all available commands
+4. Check latest AAR in `000-docs/` for current status
+
+---
+**Last Updated:** 2025-12-11

--- a/000-docs/193-AA-REPT-phase-32-reference-template-hardening.md
+++ b/000-docs/193-AA-REPT-phase-32-reference-template-hardening.md
@@ -1,0 +1,83 @@
+# Phase 32: Reference Template Hardening - AAR
+
+**Date:** 2025-12-11
+**Status:** Complete
+**Branch:** `feature/phase-32-reference-template-hardening`
+
+## Summary
+
+Made bobs-brain explicitly usable as a reference template for future IAM/agent repositories. Added comprehensive documentation for onboarding and cloning.
+
+## What Was Built
+
+### 1. Reference Map Index
+
+**File:** `000-docs/191-INDEX-bobs-brain-reference-map.md`
+
+Master index covering:
+- Quick navigation table
+- Phases & AARs (with recent phases highlighted)
+- Standards (6767 series) with key docs listed
+- Runbooks
+- Architecture docs
+- Infrastructure (Terraform, CI workflows)
+- Agent development patterns
+- Config files
+- Legacy/reference directories noted
+
+### 2. New Engineer Quickstart
+
+**File:** `000-docs/192-OVERVIEW-new-engineer-quickstart.md`
+
+Onboarding guide covering:
+- What the repo is (ADK agent department)
+- High-level architecture diagram
+- Repository structure walkthrough
+- First commands to run
+- Where to look first
+- Key rules (the "don'ts")
+- Common tasks (add agent, deploy, create docs)
+- Getting help
+
+### 3. CLAUDE.md Template Section
+
+Added new section "Using bobs-brain as a Template":
+- Steps for cloning to new repo
+- What to update (project IDs, SPIFFE IDs)
+- "Do NOT do this" list
+- Key files to customize table
+- Reference docs links
+
+### 4. Structure Verification
+
+Confirmed 000-docs/ has only two legacy subdirectories:
+- `001-usermanual/` - ADK reference notebooks (legacy)
+- `google-reference/` - Symlink to local ADK docs (reference)
+
+Both documented in index as legacy/reference, not active development.
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `000-docs/190-AA-PLAN-phase-32-reference-template-hardening.md` | Created |
+| `000-docs/191-INDEX-bobs-brain-reference-map.md` | Created |
+| `000-docs/192-OVERVIEW-new-engineer-quickstart.md` | Created |
+| `000-docs/193-AA-REPT-phase-32-reference-template-hardening.md` | Created |
+| `CLAUDE.md` | Updated (added Section 6, renumbered Section 7) |
+
+## Documentation Metrics
+
+After Phase 32:
+- Total docs in 000-docs/: ~195 files
+- New engineer-facing docs: 2 (INDEX + OVERVIEW)
+- CLAUDE.md sections: 7 (was 6)
+
+## Next Steps
+
+1. Consider cleaning up legacy subdirectories in future phase
+2. Monitor usage of template instructions
+3. Update index as new phases are added
+
+---
+**Last Updated:** 2025-12-11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,11 +320,70 @@ ls 000-docs/127-*
 
 ---
 
-## 6. Changelog / Maintenance
+## 6. Using bobs-brain as a Template
 
-**Last Update:** 2025-12-05
+This repository is designed to be a **reference implementation** that other agent repos can clone and adapt.
+
+### Steps for a New Repo
+
+1. **Clone/Copy Structure**
+   - Copy the directory structure (agents/, service/, infra/, 000-docs/)
+   - Keep Makefile, CLAUDE.md patterns
+
+2. **Update Project IDs**
+   - `infra/terraform/envs/*.tfvars` - Change all project IDs
+   - `config/agent_engine_envs.yaml` - Update project/engine mappings
+
+3. **Update SPIFFE IDs**
+   - Agent cards in `agents/*/a2a_card.py`
+   - 6767 docs referencing specific IDs
+   - Format: `spiffe://<org>/agent/<name>/<env>/<region>/<version>`
+
+4. **Re-run Validation Suite**
+   ```bash
+   make check-a2a-contracts   # Validate AgentCards
+   make arv-department        # ARV gate checks
+   make check-config          # Config validation
+   make check-all             # Full suite
+   ```
+
+### Do NOT Do This
+
+- **Don't deploy with gcloud** - Use Terraform + CI only (R4)
+- **Don't bypass Terraform/CI** - All infra changes through IaC
+- **Don't add nested folders under 000-docs/** - Keep flat (R6)
+- **Don't copy secrets directly** - Use Secret Manager references
+- **Don't skip ARV gates** - Always validate before deploy
+- **Don't import non-ADK frameworks** - Keep ADK-only (R1)
+
+### Key Files to Customize
+
+| File | What to Change |
+|------|----------------|
+| `VERSION` | Your version number |
+| `CLAUDE.md` | Your project-specific guidance |
+| `config/agent_engine_envs.yaml` | Your GCP projects and engine IDs |
+| `infra/terraform/envs/*.tfvars` | Your GCP project IDs and secrets |
+| `agents/*/a2a_card.py` | Your SPIFFE IDs and URLs |
+
+### Reference Docs for Cloning
+
+- `000-docs/191-INDEX-bobs-brain-reference-map.md` - Master doc index
+- `000-docs/192-OVERVIEW-new-engineer-quickstart.md` - Onboarding guide
+- `000-docs/6767-DR-GUIDE-porting-iam-department-to-new-repo.md` - Porting guide
+
+---
+
+## 7. Changelog / Maintenance
+
+**Last Update:** 2025-12-11
 
 **Recent Changes:**
+- **Phases 30-32 (v0.14.1+)**: Stage env baseline, promotion strategy, reference template hardening
+  - Added stage.tfvars and terraform-stage.yml workflow
+  - Created agent engine promotion config and playbook
+  - Added reference map index and new engineer quickstart
+  - Updated CLAUDE.md with template usage instructions
 - **Phase 26 (v0.14.0)**: Repository cleanup, branch archival tooling, and release
   - Created `scripts/maintenance/cleanup_branches.sh` for safe branch archival
   - Added `000-docs/ARCHIVED_BRANCHES.md` branch management index


### PR DESCRIPTION
## Summary

Makes bobs-brain explicitly usable as a reference template for future IAM/agent repos.

**Changes:**
- Created `000-docs/191-INDEX-bobs-brain-reference-map.md` - Master doc index
- Created `000-docs/192-OVERVIEW-new-engineer-quickstart.md` - Onboarding guide
- Updated `CLAUDE.md` with "Using bobs-brain as a Template" section
- Added plan and AAR documentation

**Docs-only, no runtime or infra behavior changes.**

## Test Plan
- [x] All new docs follow filing system format
- [x] Index covers key doc categories
- [x] CLAUDE.md template section is actionable
- [x] No nested directories created in 000-docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)