### PR TITLE
Phase 34: Stage Terraform Dry-Run & Safety Gates

### DIFF
--- a/.github/workflows/terraform-stage-plan.yml
+++ b/.github/workflows/terraform-stage-plan.yml
@@ -1,0 +1,172 @@
+name: Terraform Stage Plan (Dry-Run Only)
+
+# ========================================
+# STAGE ENVIRONMENT TERRAFORM PLANNING
+# ========================================
+# This workflow runs terraform plan for stage environment.
+# It NEVER runs terraform apply - stage deploys are manual.
+#
+# Safety Features:
+# - workflow_dispatch only (manual trigger)
+# - Placeholder guard (fails if TODO-SET- values remain)
+# - No apply step at all (plan only)
+#
+# Usage:
+#   Trigger manually from GitHub Actions UI to validate stage config.
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_placeholder_check:
+        description: 'Skip placeholder check (for testing workflow itself)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  TF_VERSION: '1.5.0'
+  TERRAFORM_DIR: 'infra/terraform'
+
+jobs:
+  terraform-stage-plan:
+    name: Terraform Plan (Stage)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ env.TERRAFORM_DIR }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for TODO Placeholders
+        if: ${{ !github.event.inputs.skip_placeholder_check }}
+        run: |
+          echo "🔍 Checking stage.tfvars for TODO placeholders..."
+
+          # Check for stage.tfvars (preferred) or staging.tfvars (legacy)
+          TFVARS_FILE=""
+          if [ -f "envs/stage.tfvars" ]; then
+            TFVARS_FILE="envs/stage.tfvars"
+          elif [ -f "envs/staging.tfvars" ]; then
+            TFVARS_FILE="envs/staging.tfvars"
+            echo "⚠️ Using legacy staging.tfvars (consider renaming to stage.tfvars)"
+          else
+            echo "❌ No stage/staging tfvars file found"
+            exit 1
+          fi
+
+          echo "Using: $TFVARS_FILE"
+
+          # Check for placeholder patterns
+          if grep -qE "(TODO-SET-|CHANGE-ME|PLACEHOLDER|your-project)" "$TFVARS_FILE"; then
+            echo ""
+            echo "❌ Stage tfvars contains placeholder values:"
+            echo "---"
+            grep -n -E "(TODO-SET-|CHANGE-ME|PLACEHOLDER|your-project)" "$TFVARS_FILE" || true
+            echo "---"
+            echo ""
+            echo "Replace these with real values before running terraform plan."
+            echo "See: 000-docs/188-RB-OPER-agent-engine-promotion-playbook.md"
+            exit 1
+          fi
+
+          echo "✅ No TODO placeholders found in $TFVARS_FILE"
+
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+        continue-on-error: true
+
+      - name: Check Auth Status
+        id: auth_check
+        run: |
+          if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ] || [ -n "$CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE" ]; then
+            echo "auth_available=true" >> $GITHUB_OUTPUT
+            echo "✅ GCP authentication available"
+          else
+            echo "auth_available=false" >> $GITHUB_OUTPUT
+            echo "⚠️ GCP authentication not available - running validation only"
+          fi
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: Terraform Init (Validation Mode)
+        id: init
+        run: |
+          if [ "${{ steps.auth_check.outputs.auth_available }}" == "true" ]; then
+            terraform init -backend-config="bucket=bobs-brain-terraform-state"
+          else
+            # Local state for validation only (no backend)
+            terraform init -backend=false
+          fi
+        continue-on-error: true
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        continue-on-error: true
+
+      - name: Terraform Plan (Stage)
+        id: plan
+        if: steps.auth_check.outputs.auth_available == 'true'
+        run: |
+          # Use stage.tfvars if exists, otherwise staging.tfvars
+          TFVARS_FILE="envs/staging.tfvars"
+          if [ -f "envs/stage.tfvars" ]; then
+            TFVARS_FILE="envs/stage.tfvars"
+          fi
+
+          echo "Using: $TFVARS_FILE"
+
+          terraform plan \
+            -var-file="$TFVARS_FILE" \
+            -out=tfplan-stage \
+            -no-color
+        continue-on-error: true
+
+      - name: Plan Summary
+        run: |
+          echo "## Terraform Stage Plan Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Format Check | ${{ steps.fmt.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Initialization | ${{ steps.init.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Validation | ${{ steps.validate.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Plan | ${{ steps.plan.outcome || 'skipped (no auth)' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Notes" >> $GITHUB_STEP_SUMMARY
+          echo "- This workflow **never applies** to stage" >> $GITHUB_STEP_SUMMARY
+          echo "- Stage deployment is manual (see promotion playbook)" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.auth_check.outputs.auth_available }}" != "true" ]; then
+            echo "- ⚠️ GCP auth not available - plan step was skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Final Status
+        run: |
+          echo "🏁 Stage Terraform Plan Complete"
+          echo ""
+          echo "Results:"
+          echo "  Format: ${{ steps.fmt.outcome }}"
+          echo "  Init:   ${{ steps.init.outcome }}"
+          echo "  Validate: ${{ steps.validate.outcome }}"
+          echo "  Plan:   ${{ steps.plan.outcome || 'skipped' }}"
+          echo ""
+          echo "⚠️ REMINDER: This workflow does NOT apply changes."
+          echo "   Stage deployment requires manual approval and execution."

--- a/000-docs/198-AA-PLAN-phase-34-stage-tf-dry-run-and-safety-gates.md
+++ b/000-docs/198-AA-PLAN-phase-34-stage-tf-dry-run-and-safety-gates.md
@@ -1,0 +1,63 @@
+# Phase 34: Stage Terraform Dry-Run & Safety Gates
+
+**Date:** 2025-12-11
+**Status:** In Progress
+**Branch:** `feature/phase-34-stage-tf-dry-run`
+
+## Objective
+
+Make it safe and easy to run Terraform plans for the stage environment without accidental applies. Add CI workflow with placeholder guards.
+
+## Inputs
+
+- Phase 30 `stage.tfvars` (on PR #19, not yet merged)
+- Existing `terraform-prod.yml` workflow pattern
+- Existing Terraform module structure
+
+## Non-Goals
+
+- Running `terraform apply` in any environment
+- Changing behavior of existing prod Terraform workflow
+- Modifying actual stage infrastructure
+
+## Deliverables
+
+1. **Stage Plan Workflow**
+   - `.github/workflows/terraform-stage-plan.yml`
+   - Trigger: `workflow_dispatch` only (manual)
+   - Steps: fmt, init, validate, plan
+   - Placeholder guard to catch TODO values
+
+2. **Stage tfvars** (if not already present)
+   - `infra/terraform/envs/stage.tfvars`
+   - With clear TODO placeholders for values needing real IDs
+
+3. **Documentation**
+   - Phase PLAN doc (this file)
+   - Phase AAR doc (after completion)
+
+## Implementation Steps
+
+1. Create plan doc (this file)
+2. Create/verify stage.tfvars exists
+3. Create terraform-stage-plan.yml workflow
+4. Add placeholder guard step
+5. Test locally (terraform fmt, validate)
+6. Create AAR
+
+## Safety Guards
+
+The workflow will include:
+```yaml
+- name: Ensure stage tfvars has no TODO placeholders
+  run: |
+    if grep -q "TODO-SET-" infra/terraform/envs/stage.tfvars; then
+      echo "Stage tfvars still contains TODO placeholders."
+      exit 1
+    fi
+```
+
+This ensures real plans only run after TODOs are replaced with actual values.
+
+---
+**Last Updated:** 2025-12-11

--- a/000-docs/199-AA-REPT-phase-34-stage-tf-dry-run-and-safety-gates.md
+++ b/000-docs/199-AA-REPT-phase-34-stage-tf-dry-run-and-safety-gates.md
@@ -1,0 +1,115 @@
+# Phase 34: Stage Terraform Dry-Run & Safety Gates - AAR
+
+**Date:** 2025-12-11
+**Status:** Complete
+**Branch:** `feature/phase-34-stage-tf-dry-run`
+
+## Summary
+
+Created a safe, plan-only Terraform workflow for stage environment with placeholder guards to prevent premature execution.
+
+## What Was Built
+
+### 1. Stage Plan Workflow
+
+**File:** `.github/workflows/terraform-stage-plan.yml`
+
+Features:
+- Manual trigger only (`workflow_dispatch`)
+- Placeholder guard step (fails if `TODO-SET-` patterns remain)
+- Format check, init, validate, plan steps
+- No apply step at all (plan only)
+- Graceful handling when GCP auth not available
+- Clear summary output
+
+### 2. Stage Environment Config
+
+**File:** `infra/terraform/envs/stage.tfvars`
+
+Contents:
+- Current version (v0.14.1) aligned config
+- Clear TODO placeholders for project IDs
+- Secret Manager references for Slack secrets
+- SPIFFE ID for stage environment
+- Org storage hub config (disabled by default)
+
+### 3. Terraform Formatting
+
+Fixed terraform format issues in:
+- `cloud_run.tf`
+- `envs/prod.tfvars`
+- `envs/stage.tfvars`
+- `modules/slack_bob_gateway/main.tf`
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `.github/workflows/terraform-stage-plan.yml` | Created |
+| `infra/terraform/envs/stage.tfvars` | Created |
+| `infra/terraform/cloud_run.tf` | Formatted |
+| `infra/terraform/envs/prod.tfvars` | Formatted |
+| `infra/terraform/modules/slack_bob_gateway/main.tf` | Formatted |
+| `000-docs/198-AA-PLAN-phase-34-stage-tf-dry-run-and-safety-gates.md` | Created |
+| `000-docs/199-AA-REPT-phase-34-stage-tf-dry-run-and-safety-gates.md` | Created |
+
+## Safety Features
+
+### Placeholder Guard
+
+The workflow checks for patterns:
+- `TODO-SET-`
+- `CHANGE-ME`
+- `PLACEHOLDER`
+- `your-project`
+
+If any are found, the workflow fails with clear output showing which lines need updating.
+
+### No Apply Step
+
+Unlike `terraform-prod.yml`, this workflow has no apply capability. Stage deployment is intentionally manual.
+
+### Validation Mode
+
+When GCP auth is unavailable:
+- Runs `terraform init -backend=false`
+- Runs format and validate checks
+- Skips plan step (requires auth)
+- Clearly documents this in summary
+
+## Test Results
+
+```bash
+$ terraform fmt -check -recursive
+# Fixed 4 files
+
+$ terraform init -backend=false
+Terraform has been successfully initialized!
+
+$ terraform validate
+Success! The configuration is valid.
+```
+
+## Usage
+
+### Running Stage Plan
+
+1. Navigate to Actions → "Terraform Stage Plan (Dry-Run Only)"
+2. Click "Run workflow"
+3. Review results in workflow summary
+
+### Enabling Real Plans
+
+1. Replace all `TODO-SET-STAGE-PROJECT-ID` with actual project ID
+2. Ensure WIF credentials are configured
+3. Re-run workflow
+
+## Next Steps
+
+1. Create stage GCP project
+2. Configure WIF for stage environment
+3. Replace TODO placeholders with real values
+4. Run first real stage plan
+
+---
+**Last Updated:** 2025-12-11

--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -155,7 +155,7 @@ module "slack_bob_gateway" {
   agent_engine_id   = tostring(google_vertex_ai_reasoning_engine.bob.id)
 
   # Secret Manager references (production best practice)
-  slack_signing_secret_id = var.slack_signing_secret_id
+  slack_signing_secret_id   = var.slack_signing_secret_id
   slack_bot_token_secret_id = var.slack_bot_token_secret_id
 
   # Service account

--- a/infra/terraform/envs/prod.tfvars
+++ b/infra/terraform/envs/prod.tfvars
@@ -26,8 +26,8 @@ slack_bob_enabled = true
 
 # Secret Manager references (production best practice)
 # Secrets must exist in Secret Manager before deployment
-slack_bot_token_secret_id      = "slack-bot-token"
-slack_signing_secret_id        = "slack-signing-secret"
+slack_bot_token_secret_id = "slack-bot-token"
+slack_signing_secret_id   = "slack-signing-secret"
 
 # DEPRECATED: Direct token variables (use Secret Manager instead)
 slack_bot_token      = "" # Ignored when slack_bot_token_secret_id is set

--- a/infra/terraform/envs/stage.tfvars
+++ b/infra/terraform/envs/stage.tfvars
@@ -1,0 +1,77 @@
+# Stage Environment Configuration
+# terraform plan -var-file="envs/stage.tfvars"
+#
+# NOTE: This file contains TODO placeholders that MUST be replaced
+# before running terraform plan/apply. The terraform-stage-plan.yml
+# workflow will fail if these placeholders remain.
+
+# Project Configuration
+project_id  = "TODO-SET-STAGE-PROJECT-ID" # e.g., "bobs-brain-stage"
+region      = "us-central1"
+environment = "stage"
+
+# Application Configuration
+app_name    = "bobs-brain"
+app_version = "0.14.1"
+
+# Agent Engine Configuration
+# Bob agent (main orchestrator)
+bob_docker_image = "gcr.io/TODO-SET-STAGE-PROJECT-ID/agent:0.14.1"
+
+# Foreman agent (iam-senior-adk-devops-lead)
+foreman_docker_image = "gcr.io/TODO-SET-STAGE-PROJECT-ID/foreman:0.14.1"
+
+# Agent Engine compute resources
+agent_machine_type = "n1-standard-2"
+agent_max_replicas = 3
+
+# Gateway Configuration
+a2a_gateway_image     = "gcr.io/TODO-SET-STAGE-PROJECT-ID/a2a-gateway:0.14.1"
+slack_webhook_image   = "gcr.io/TODO-SET-STAGE-PROJECT-ID/slack-webhook:0.14.1"
+gateway_max_instances = 5
+
+# Slack Configuration (stage credentials)
+# IMPORTANT: These should reference Secret Manager secrets, not plaintext
+slack_bot_token_secret_id      = "slack-bot-token-stage"
+slack_signing_secret_secret_id = "slack-signing-secret-stage"
+
+# SPIFFE ID (R7) - Bob agent
+agent_spiffe_id = "spiffe://intent.solutions/agent/bobs-brain/stage/us-central1/0.14.1"
+
+# AI Model Configuration
+model_name = "gemini-2.0-flash-exp"
+
+# Vertex AI Search Configuration
+vertex_search_datastore_id = "adk-documentation"
+
+# Networking
+allow_public_access = true
+
+# Labels
+labels = {
+  cost_center = "staging"
+  team        = "platform"
+  env         = "stage"
+}
+
+# ADK Deployment Configuration
+# Staging bucket: gs://<project-id>-adk-staging
+
+# Knowledge Hub Configuration
+knowledge_hub_project_id = "datahub-intent"
+knowledge_bucket_prefix  = "datahub-intent"
+
+# Service accounts (to be configured after project setup)
+bobs_brain_runtime_sa = ""
+bobs_brain_search_sa  = ""
+
+# Consumer service accounts
+consumer_service_accounts = []
+
+# ==============================================================================
+# Org-Wide Knowledge Hub (LIVE1-GCS)
+# ==============================================================================
+org_storage_enabled                 = false
+org_storage_bucket_name             = "intent-org-knowledge-hub-stage"
+org_storage_location                = "US"
+org_storage_writer_service_accounts = []

--- a/infra/terraform/modules/slack_bob_gateway/main.tf
+++ b/infra/terraform/modules/slack_bob_gateway/main.tf
@@ -14,7 +14,7 @@ terraform {
 
 # Conditional resource creation based on enable flag
 locals {
-  enabled = var.enable ? 1 : 0
+  enabled      = var.enable ? 1 : 0
   service_name = "${var.app_name}-slack-webhook-${var.environment}"
 }
 


### PR DESCRIPTION
## Summary

Adds safe, plan-only Terraform workflow for stage environment with placeholder guards.

- `.github/workflows/terraform-stage-plan.yml` - Manual trigger, plan only, no apply
- `infra/terraform/envs/stage.tfvars` - Stage config with TODO placeholders
- Fixed terraform formatting across 4 files

## Safety Features

1. **Placeholder Guard**: Fails if `TODO-SET-` patterns remain in tfvars
2. **No Apply Step**: Workflow can only plan, not apply
3. **Manual Trigger Only**: `workflow_dispatch` prevents accidental runs
4. **Graceful Auth Handling**: Runs validation even without GCP credentials

## Test Plan

- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] Workflow syntax valid
- [ ] Trigger workflow from Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)