### PR TITLE
feat(infra): add MCP server config to staging/prod

### DIFF
--- a/infra/terraform/envs/prod.tfvars
+++ b/infra/terraform/envs/prod.tfvars
@@ -20,6 +20,11 @@ a2a_gateway_image     = "gcr.io/bobs-brain/a2a-gateway:0.6.0"
 slack_webhook_image   = "gcr.io/bobs-brain/slack-webhook:0.6.0"
 gateway_max_instances = 20 # More instances for production
 
+# MCP Server Configuration (Phase H - Universal Tool Access)
+# Enable when MCP server is production-tested
+bobs_mcp_enabled = false
+bobs_mcp_image   = "gcr.io/bobs-brain/bobs-mcp:0.2.0"
+
 # Slack Configuration (production)
 # Feature flag to enable Slack Bob gateway (R3 Cloud Run proxy)
 slack_bob_enabled = true

--- a/infra/terraform/envs/staging.tfvars
+++ b/infra/terraform/envs/staging.tfvars
@@ -20,6 +20,11 @@ a2a_gateway_image     = "gcr.io/bobs-brain-staging/a2a-gateway:0.6.0"
 slack_webhook_image   = "gcr.io/bobs-brain-staging/slack-webhook:0.6.0"
 gateway_max_instances = 10
 
+# MCP Server Configuration (Phase H - Universal Tool Access)
+# Enable when ready to test MCP in staging
+bobs_mcp_enabled = false
+bobs_mcp_image   = "gcr.io/bobs-brain-staging/bobs-mcp:0.2.0"
+
 # Slack Configuration (staging credentials)
 # IMPORTANT: Use Secret Manager or CI/CD secrets in production
 slack_bot_token      = "xoxb-staging-placeholder"


### PR DESCRIPTION
## Summary
- Add `bobs_mcp_enabled` and `bobs_mcp_image` variables to staging and prod tfvars
- MCP is disabled by default in staging/prod (pending production testing)
- Dev already has MCP enabled (Phase H+)

## Context
The MCP server infrastructure (Cloud Run service, IAM, etc.) was already fully implemented in `cloud_run.tf`. This PR adds the configuration variables to staging and prod environments for consistency.

**Current MCP status by environment:**
| Environment | bobs_mcp_enabled | Status |
|-------------|------------------|--------|
| dev | `true` | Ready for testing |
| staging | `false` | Config added, disabled |
| prod | `false` | Config added, disabled |

## Test plan
- [x] Mission Spec validate/dry-run works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)