### PR TITLE
fix: address PR #65 review feedback (env vars, tree diagram, flag consistency)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ agents/
 ├── iam_doc/                      # Tier 3: Documentation writer
 ├── iam_cleanup/                  # Tier 3: Repo cleanup
 ├── iam_index/                    # Tier 3: Knowledge indexing
-│
+│                                 # --- Infrastructure/utility directories ---
 ├── a2a/                          # A2A protocol implementation
 ├── agent_engine/                 # Agent Engine integration/config
 ├── arv/                          # Agent Readiness Verification

--- a/Makefile
+++ b/Makefile
@@ -432,8 +432,8 @@ deploy-inline-staging-execute: check-inline-deploy-ready ## MANUAL ONLY: Execute
 
 smoke-bob-agent-engine-dev: ## Run dev smoke test against Bob's Agent Engine instance
 	@echo "$(BLUE)🚦 Running Bob Agent Engine dev smoke test...$(NC)"
-	@echo "$(YELLOW)ℹ️  Requires BOB_AGENT_ENGINE_NAME_DEV to be set after dev deployment$(NC)"
-	@$(PYTHON) scripts/run_agent_engine_dev_smoke.py --agent bob
+	@echo "$(YELLOW)ℹ️  Requires AGENT_ENGINE_BOB_DEV to be set after dev deployment$(NC)"
+	@$(PYTHON) scripts/run_agent_engine_dev_smoke.py
 	@echo ""
 
 ## ============================================================================

--- a/scripts/run_agent_engine_dev_smoke.py
+++ b/scripts/run_agent_engine_dev_smoke.py
@@ -15,7 +15,7 @@ This is a DEV-ONLY smoke test. It validates that:
 
 Requirements:
 - DEPLOYMENT_ENV=dev
-- AGENT_ENGINE_BOB_ID_DEV set (or another agent configured)
+- AGENT_ENGINE_BOB_DEV set (or another agent configured)
 - GCP Application Default Credentials (gcloud auth application-default login)
 - Agent Engine deployed and accessible
 
@@ -130,7 +130,7 @@ async def run_smoke_test(
         )
         print("   To configure:")
         print(
-            f"     export AGENT_ENGINE_{agent_role.replace('-', '_').upper()}_ID_DEV=your-engine-id"
+            f"     export AGENT_ENGINE_{agent_role.replace('-', '_').upper()}_DEV=your-engine-id"
         )
         print()
         print("✅ Smoke test completed (agent not configured - non-blocking)")


### PR DESCRIPTION
## Summary
Fixes 3 issues flagged by automated reviewers on PR #65:

- **Qodo bug**: Makefile `smoke-bob-agent-engine-dev` referenced legacy env var `BOB_AGENT_ENGINE_NAME_DEV` — updated to `AGENT_ENGINE_BOB_DEV` (what `agents/config/agent_engine.py` actually reads)
- **Qodo/CodeRabbit**: Smoke script printed `AGENT_ENGINE_*_ID_DEV` in guidance but config expects `AGENT_ENGINE_*_DEV` (no `_ID`) — fixed docstring and runtime message
- **Gemini**: CLAUDE.md tree diagram had ambiguous `│` between agent and infrastructure directories — added separator comment for clarity
- **CodeRabbit**: Removed redundant `--agent bob` flag from Makefile target (bob is already the default)

## Test plan
- [ ] CI passes
- [ ] `make smoke-bob-agent-engine-dev` shows correct env var name
- [ ] `python3 scripts/run_agent_engine_dev_smoke.py` prints correct env var in guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and enhanced documentation covering infrastructure directories, utility components, and the overall project directory structure layout.

* **Chores**
  * Streamlined the development smoke test setup process by removing explicit hardcoded agent parameters from the automated test execution.
  * Updated and standardized environment variable naming conventions across all development configuration tools and scripts for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->