### PR TITLE
fix(config): align AGENT_ENGINE env var convention to _ID_ pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,7 @@ deploy-inline-staging-execute: check-inline-deploy-ready ## MANUAL ONLY: Execute
 
 smoke-bob-agent-engine-dev: ## Run dev smoke test against Bob's Agent Engine instance
 	@echo "$(BLUE)🚦 Running Bob Agent Engine dev smoke test...$(NC)"
-	@echo "$(YELLOW)ℹ️  Requires AGENT_ENGINE_BOB_DEV to be set after dev deployment$(NC)"
+	@echo "$(YELLOW)ℹ️  Requires AGENT_ENGINE_BOB_ID_DEV to be set after dev deployment$(NC)"
 	@$(PYTHON) scripts/run_agent_engine_dev_smoke.py
 	@echo ""
 

--- a/agents/config/agent_engine.py
+++ b/agents/config/agent_engine.py
@@ -17,7 +17,7 @@ Environment Variables:
 - AGENT_ENGINE_FOREMAN_ID_DEV: Foreman's Engine ID in dev
 - AGENT_ENGINE_BOB_ID_STAGING: Bob's Engine ID in staging
 - AGENT_ENGINE_BOB_ID_PROD: Bob's Engine ID in prod
-- (Additional agents: AGENT_ENGINE_{AGENT}_{ENV})
+- (Additional agents: AGENT_ENGINE_{AGENT}_ID_{ENV})
 
 Related Docs:
 - 000-docs/6767-101-AT-ARCH-agent-engine-topology-and-envs.md
@@ -120,7 +120,7 @@ def get_agent_engine_id(
     Get Agent Engine ID for a specific agent role and environment.
 
     Checks environment variables in this order:
-    1. AGENT_ENGINE_{AGENT}_{ENV} (e.g., AGENT_ENGINE_BOB_DEV)
+    1. AGENT_ENGINE_{AGENT}_ID_{ENV} (e.g., AGENT_ENGINE_BOB_ID_DEV)
     2. Falls back to hardcoded defaults for known agents
 
     Args:
@@ -131,7 +131,7 @@ def get_agent_engine_id(
         Engine ID or None if not configured
 
     Examples:
-        >>> os.environ["AGENT_ENGINE_BOB_DEV"] = "12345"
+        >>> os.environ["AGENT_ENGINE_BOB_ID_DEV"] = "12345"
         >>> get_agent_engine_id("bob", "dev")
         "12345"
 
@@ -143,7 +143,7 @@ def get_agent_engine_id(
 
     # Normalize agent role for env var (replace dashes with underscores, uppercase)
     agent_var_name = agent_role.replace("-", "_").upper()
-    env_var_name = f"AGENT_ENGINE_{agent_var_name}_{env.upper()}"
+    env_var_name = f"AGENT_ENGINE_{agent_var_name}_ID_{env.upper()}"
 
     engine_id = _get_env_var(env_var_name)
     if engine_id:
@@ -237,7 +237,7 @@ def build_agent_config(
         AgentEngineConfig if engine ID is configured, None otherwise
 
     Examples:
-        >>> os.environ["AGENT_ENGINE_BOB_DEV"] = "12345"
+        >>> os.environ["AGENT_ENGINE_BOB_ID_DEV"] = "12345"
         >>> config = build_agent_config("bob", "dev")
         >>> print(config.get_full_resource_name())
         "projects/my-project/locations/us-central1/reasoningEngines/12345"
@@ -401,7 +401,7 @@ def validate_config(env: Optional[Environment] = None) -> None:
     if not configured_agents:
         raise ValueError(
             f"No agents configured for {env} environment. "
-            f"Set at least AGENT_ENGINE_BOB_{env.upper()} environment variable."
+            f"Set at least AGENT_ENGINE_BOB_ID_{env.upper()} environment variable."
         )
 
     print(f"✅ Agent Engine configuration valid for {env}")
@@ -448,7 +448,7 @@ if __name__ == "__main__":
         print(f"  No agents configured for {env} environment")
         print()
         print("  Set environment variables like:")
-        print(f"    export AGENT_ENGINE_BOB_{env.upper()}=your-engine-id")
+        print(f"    export AGENT_ENGINE_BOB_ID_{env.upper()}=your-engine-id")
     else:
         for role, config in agents.items():
             print(f"  {role}:")

--- a/scripts/run_agent_engine_dev_smoke.py
+++ b/scripts/run_agent_engine_dev_smoke.py
@@ -15,7 +15,7 @@ This is a DEV-ONLY smoke test. It validates that:
 
 Requirements:
 - DEPLOYMENT_ENV=dev
-- AGENT_ENGINE_BOB_DEV set (or another agent configured)
+- AGENT_ENGINE_BOB_ID_DEV set (or another agent configured)
 - GCP Application Default Credentials (gcloud auth application-default login)
 - Agent Engine deployed and accessible
 
@@ -130,7 +130,7 @@ async def run_smoke_test(
         )
         print("   To configure:")
         print(
-            f"     export AGENT_ENGINE_{agent_role.replace('-', '_').upper()}_DEV=your-engine-id"
+            f"     export AGENT_ENGINE_{agent_role.replace('-', '_').upper()}_ID_DEV=your-engine-id"
         )
         print()
         print("✅ Smoke test completed (agent not configured - non-blocking)")


### PR DESCRIPTION
## Summary
Fixes the env var contract mismatch flagged by Greptile and Qodo on PR #66.

**Root cause**: `agents/config/agent_engine.py:146` constructed env var names as `AGENT_ENGINE_{AGENT}_{ENV}` (e.g. `AGENT_ENGINE_BOB_DEV`), but the canonical convention used everywhere else was `AGENT_ENGINE_{AGENT}_ID_{ENV}` (e.g. `AGENT_ENGINE_BOB_ID_DEV`).

**Impact**: Users following documented setup (inventory.py, docs, test examples) would set `AGENT_ENGINE_BOB_ID_DEV` but the runtime looked for `AGENT_ENGINE_BOB_DEV` — resulting in "agent not configured" errors.

**Fix**: Added `_ID_` to the runtime env var construction to match the canonical convention. Updated all docstrings, examples, Makefile echo, and smoke script guidance to be consistent.

Files changed:
- `agents/config/agent_engine.py` — runtime construction + docstrings/examples
- `Makefile` — env var in echo message
- `scripts/run_agent_engine_dev_smoke.py` — guidance output + docstring

## Test plan
- [ ] CI passes (existing test at `test_agent_engine_client.py:49` already uses `AGENT_ENGINE_BOB_ID_DEV`)
- [ ] `grep -r "AGENT_ENGINE_BOB_DEV" agents/ scripts/ Makefile` returns zero matches (only `_ID_DEV`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated environment variable naming convention for agent engine configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->