### PR TITLE
docs: freeze v1 (ADK era) — superseded by bobs-brain-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # 🤖 Bob's Brain
 
+> ## ❄️ FROZEN — v1 (ADK era). Superseded by [`bobs-brain-v2`](https://github.com/jeremylongshore/bobs-brain-v2).
+>
+> This repository is the **v1 reference artifact**: a production-grade Google **ADK + Vertex AI
+> Agent Engine** agent department. Its Hard Mode constitution (R1 ADK-only, R2 Vertex runtime,
+> R5 Vertex memory) *mandates* Google. It is preserved as honest evidence of the ADK era and is
+> **no longer under active development**.
+>
+> The successor — **[`bobs-brain-v2`](https://github.com/jeremylongshore/bobs-brain-v2)** — is a
+> greenfield, **BYOK any-provider, zero-Google-by-default** governed agent (Pydantic AI + LiteLLM),
+> governed by the Intent Eval Platform attestation kernel. New work happens there.
+
 <div align="center">
 
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)


### PR DESCRIPTION
## What

Adds a freeze banner to the top of the README marking **Bob's Brain (this repo, v1)** as the
**ADK-era reference artifact**, no longer under active development.

## Why

v1's Hard Mode constitution (R1 ADK-only, R2 Vertex runtime, R5 Vertex memory) *mandates*
Google. The new dogfooding goal — **any provider, zero Google by default** — is structurally
unsatisfiable here without gutting the constitution + 185 docs. So v1 is preserved as honest
ADK-era evidence, and new work moves to the greenfield successor:

**[`bobs-brain-v2`](https://github.com/jeremylongshore/bobs-brain-v2)** — BYOK any-provider,
zero-Google-default, Pydantic AI + LiteLLM, governed by the IEP attestation kernel.

Tracked as bead `bobs-brain-v2-gsx.3` (GitHub: jeremylongshore/bobs-brain-v2#12).

- Jeremy Longshore
intentsolutions.io