### PR TITLE
fix(iam): reconcile ADK identity and harden security gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,6 @@ jobs:
 
       - name: Run Bandit security scan
         run: bandit -r agents/ service/ -ll -i
-        continue-on-error: true  # Pre-existing findings in agents/service; TODO: fix and make blocking
 
       - name: Audit dependencies for vulnerabilities
         run: pip-audit --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -208,7 +208,7 @@ jobs:
           OTEL_TRACES_EXPORTER: none
 
       - name: Enforce coverage threshold (>= 35%)
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.12'
         run: |
           coverage report --fail-under=35
 
@@ -220,7 +220,7 @@ jobs:
           BOB_STUB_EXTERNAL: "1"
 
       - name: Upload coverage
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ name: CI - Hard Mode
 # - Code quality, tests, security, Terraform, docs, structure
 #
 # Deployment workflows MUST depend on this workflow's success.
-# Badge: [![CI](https://github.com/jeremylongshore/bobs-brain/workflows/CI%20-%20Hard%20Mode/badge.svg)](https://github.com/jeremylongshore/bobs-brain/actions/workflows/ci.yml)
+# Badge: [![CI](https://github.com/jeremylongshore/iam-bob-adk/workflows/CI%20-%20Hard%20Mode/badge.svg)](https://github.com/jeremylongshore/iam-bob-adk/actions/workflows/ci.yml)
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🤖 Bob's Brain
+# iam-bob-adk — Google ADK reference implementation of the Intent Agent Model
 
 > **Intent Agent Model (IAM)** — *not* Identity and Access Management.  
 > Bob is the **reference implementation family** for IAM. These repos are different **runtimes** of the same model, not separate products.
@@ -323,8 +323,8 @@ If drift check fails, the entire pipeline stops. No tests run. No deployment hap
 
 ```bash
 # Get the code
-git clone https://github.com/intent-solutions-io/bobs-brain.git
-cd bobs-brain
+git clone https://github.com/jeremylongshore/iam-bob-adk.git
+cd iam-bob-adk
 
 # Set up Python environment
 python3 -m venv .venv
@@ -1118,8 +1118,8 @@ Just keep the license notice and don't blame us if things break. 😊
 ## 🔗 Resources
 
 **This Project:**
-- [GitHub Repository](https://github.com/intent-solutions-io/bobs-brain)
-- [Release Notes](https://github.com/intent-solutions-io/bobs-brain/releases)
+- [GitHub Repository](https://github.com/jeremylongshore/iam-bob-adk)
+- [Release Notes](https://github.com/jeremylongshore/iam-bob-adk/releases)
 - [Documentation](000-docs/)
 
 **Foundation Template:**
@@ -1141,6 +1141,6 @@ Just keep the license notice and don't blame us if things break. 😊
 
 **Built with ❤️ using Google ADK**
 
-[⭐ Star us on GitHub](https://github.com/intent-solutions-io/bobs-brain) • [📖 Read the docs](000-docs/) • [💬 Join the discussion](https://github.com/intent-solutions-io/bobs-brain/discussions)
+[⭐ Star us on GitHub](https://github.com/jeremylongshore/iam-bob-adk) • [📖 Read the docs](000-docs/) • [💬 Join the discussion](https://github.com/jeremylongshore/iam-bob-adk/discussions)
 
 </div>

--- a/agents/arv/check_impl.py
+++ b/agents/arv/check_impl.py
@@ -6,6 +6,7 @@ Each function executes a check and returns an ArvResult.
 """
 
 import os
+import shlex
 import subprocess
 
 from agents.arv.spec import ArvCheck, ArvResult, Environment
@@ -93,10 +94,13 @@ def run_check(check: ArvCheck, env: Environment, verbose: bool = False) -> ArvRe
         check_env["DEPLOYMENT_ENV"] = env
 
         # Run the command
+        command = shlex.split(check.command)
+        if not command:
+            raise ValueError("ARV check command must not be empty")
+
         result = subprocess.run(
-            check.command,
+            command,
             check=False,
-            shell=True,
             capture_output=True,
             text=True,
             timeout=300,  # 5 minute timeout

--- a/agents/arv/spec.py
+++ b/agents/arv/spec.py
@@ -28,7 +28,7 @@ class ArvCheck:
         description: Human-readable description
         category: Logical grouping
         required: Whether this check is required for the environment
-        command: Shell command or script to execute
+        command: Command line to execute directly, without a shell
         required_when: Optional condition (e.g., "LIVE_RAG_BOB_ENABLED=true")
         envs: Environments where this check applies
     """

--- a/agents/bob/.well-known/agent-card.json
+++ b/agents/bob/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "adk_expertise",

--- a/agents/iam_adk/.well-known/agent-card.json
+++ b/agents/iam_adk/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "adk_pattern_analysis",

--- a/agents/iam_adk/README.md
+++ b/agents/iam_adk/README.md
@@ -343,6 +343,6 @@ agents/iam-adk/
 ## Contact
 
 - **Owner:** iam-senior-adk-devops-lead
-- **Repository:** https://github.com/jeremylongshore/bobs-brain
+- **Repository:** https://github.com/jeremylongshore/iam-bob-adk
 - **Version:** 0.8.0
 - **Last Updated:** 2025-11-19

--- a/agents/iam_adk/agent_card.yaml
+++ b/agents/iam_adk/agent_card.yaml
@@ -224,4 +224,4 @@ metadata:
   version: "0.8.0"
   status: "active"
   owner: "iam-senior-adk-devops-lead"
-  repository: "https://github.com/jeremylongshore/bobs-brain"
+  repository: "https://github.com/jeremylongshore/iam-bob-adk"

--- a/agents/iam_cleanup/.well-known/agent-card.json
+++ b/agents/iam_cleanup/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "dead_code_detection",

--- a/agents/iam_cleanup/README.md
+++ b/agents/iam_cleanup/README.md
@@ -241,7 +241,7 @@ Deploy via GitHub Actions (enforced by R4):
 git push origin main
 
 # Manual trigger for specific environments
-# Go to: https://github.com/jeremylongshore/bobs-brain/actions
+# Go to: https://github.com/jeremylongshore/iam-bob-adk/actions
 # Run "Deploy to Vertex AI Agent Engine"
 ```
 

--- a/agents/iam_doc/.well-known/agent-card.json
+++ b/agents/iam_doc/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "aar_generation",

--- a/agents/iam_fix_impl/.well-known/agent-card.json
+++ b/agents/iam_fix_impl/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "code_implementation",

--- a/agents/iam_fix_plan/.well-known/agent-card.json
+++ b/agents/iam_fix_plan/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "fix_strategy_design",

--- a/agents/iam_index/.well-known/agent-card.json
+++ b/agents/iam_index/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "vertex_search_management",

--- a/agents/iam_index/tools/indexing_tools.py
+++ b/agents/iam_index/tools/indexing_tools.py
@@ -264,7 +264,9 @@ def generate_index_entry(
             content_type = "doc"  # Default to doc
 
         # Generate a simple entry ID
-        entry_id = hashlib.md5(f"{title}{source}".encode()).hexdigest()[:12]
+        entry_id = hashlib.md5(
+            f"{title}{source}".encode(), usedforsecurity=False
+        ).hexdigest()[:12]
 
         # Create IndexEntry
         entry = IndexEntry(

--- a/agents/iam_issue/.well-known/agent-card.json
+++ b/agents/iam_issue/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "issue_authoring",

--- a/agents/iam_qa/.well-known/agent-card.json
+++ b/agents/iam_qa/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "test_design",

--- a/agents/iam_senior_adk_devops_lead/.well-known/agent-card.json
+++ b/agents/iam_senior_adk_devops_lead/.well-known/agent-card.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "task_routing",

--- a/agents/notifications/slack_formatter.py
+++ b/agents/notifications/slack_formatter.py
@@ -161,7 +161,7 @@ def _make_footer_block(result: PortfolioResult) -> Dict[str, Any]:
 
     footer_text = (
         f"Completed at {timestamp_str} | "
-        f"<https://github.com/jeremylongshore/bobs-brain|View Project>"
+        f"<https://github.com/jeremylongshore/iam-bob-adk|View Project>"
     )
 
     return {"type": "context", "elements": [{"type": "mrkdwn", "text": footer_text}]}

--- a/ai-card-examples/bobs-brain/README.md
+++ b/ai-card-examples/bobs-brain/README.md
@@ -2,7 +2,7 @@
 
 **Status:** Production-grade multi-agent system  
 **Tech Stack:** Google ADK 1.18.0, Vertex AI Agent Engine, A2A Protocol 0.3.0  
-**Repository:** https://github.com/jeremylongshore/bobs-brain
+**Repository:** https://github.com/jeremylongshore/iam-bob-adk
 
 ---
 
@@ -135,7 +135,7 @@ spiffe://intent.solutions/agent/bobs-brain/prod/us-central1/0.12.0
 
 ## Links
 
-- **Repository:** https://github.com/jeremylongshore/bobs-brain
+- **Repository:** https://github.com/jeremylongshore/iam-bob-adk
 - **Documentation:** See `000-docs/` directory
 - **Master Index:** `000-docs/6767-DR-INDEX-bobs-brain-standards-catalog.md`
 - **Hard Mode Spec:** `000-docs/6767-DR-STND-adk-agent-engine-spec-and-hardmode-rules.md`

--- a/ai-card-examples/bobs-brain/agent-card-a2a.json
+++ b/ai-card-examples/bobs-brain/agent-card-a2a.json
@@ -15,7 +15,7 @@
     "organization": "Intent Solutions",
     "url": "https://intent.solutions"
   },
-  "documentation_url": "https://github.com/jeremylongshore/bobs-brain",
+  "documentation_url": "https://github.com/jeremylongshore/iam-bob-adk",
   "icon_url": null,
   "capabilities": [
     "adk_expertise",

--- a/ai-card-examples/bobs-brain/ai-card.json
+++ b/ai-card-examples/bobs-brain/ai-card.json
@@ -223,6 +223,6 @@
     "documentation_files": 141,
     "canonical_standards": 28,
     "test_coverage": "65%+",
-    "repository": "https://github.com/jeremylongshore/bobs-brain"
+    "repository": "https://github.com/jeremylongshore/iam-bob-adk"
   }
 }

--- a/ai-card-examples/bobs-brain/conversion-guide.md
+++ b/ai-card-examples/bobs-brain/conversion-guide.md
@@ -392,7 +392,7 @@ diff <(jq -S 'keys' agent-card-a2a.json) <(jq -S '.services.a2a.protocolSpecific
 
 ## Questions?
 
-- **Repository:** https://github.com/jeremylongshore/bobs-brain
+- **Repository:** https://github.com/jeremylongshore/iam-bob-adk
 - **Issues:** https://github.com/Agent-Card/ai-card/issues
 - **Contact:** jeremy@intentsolutions.io
 

--- a/github-pages/README.md
+++ b/github-pages/README.md
@@ -52,15 +52,15 @@ The version badge is currently hardcoded to `v0.9.0`. When updating the VERSION 
 
 All links point to the current repository structure:
 
-- **GitHub Repository:** https://github.com/jeremylongshore/bobs-brain
-- **Documentation:** https://github.com/jeremylongshore/bobs-brain/tree/main/000-docs
-- **README:** https://github.com/jeremylongshore/bobs-brain/blob/main/README.md
-- **CLAUDE.md:** https://github.com/jeremylongshore/bobs-brain/blob/main/CLAUDE.md
-- **CHANGELOG:** https://github.com/jeremylongshore/bobs-brain/blob/main/CHANGELOG.md
-- **DevOps Playbook:** https://github.com/jeremylongshore/bobs-brain/blob/main/000-docs/120-AA-AUDT-appaudit-devops-playbook.md
-- **LIVE3 Guide:** https://github.com/jeremylongshore/bobs-brain/blob/main/000-docs/121-DR-GUIDE-live3-dev-smoke-test.md
-- **Issues:** https://github.com/jeremylongshore/bobs-brain/issues
-- **License:** https://github.com/jeremylongshore/bobs-brain/blob/main/LICENSE
+- **GitHub Repository:** https://github.com/jeremylongshore/iam-bob-adk
+- **Documentation:** https://github.com/jeremylongshore/iam-bob-adk/tree/main/000-docs
+- **README:** https://github.com/jeremylongshore/iam-bob-adk/blob/main/README.md
+- **CLAUDE.md:** https://github.com/jeremylongshore/iam-bob-adk/blob/main/CLAUDE.md
+- **CHANGELOG:** https://github.com/jeremylongshore/iam-bob-adk/blob/main/CHANGELOG.md
+- **DevOps Playbook:** https://github.com/jeremylongshore/iam-bob-adk/blob/main/000-docs/120-AA-AUDT-appaudit-devops-playbook.md
+- **LIVE3 Guide:** https://github.com/jeremylongshore/iam-bob-adk/blob/main/000-docs/121-DR-GUIDE-live3-dev-smoke-test.md
+- **Issues:** https://github.com/jeremylongshore/iam-bob-adk/issues
+- **License:** https://github.com/jeremylongshore/iam-bob-adk/blob/main/LICENSE
 - **Intent Solutions:** https://intentsolutions.io
 - **Google ADK:** https://cloud.google.com/vertex-ai/docs/agent-development-kit
 - **Vertex AI Agent Engine:** https://cloud.google.com/vertex-ai/docs/agent-engine

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -61,10 +61,10 @@
 
                 <!-- Primary Actions -->
                 <div class="hero-actions">
-                    <a href="https://github.com/jeremylongshore/bobs-brain" class="btn btn-primary" target="_blank" rel="noopener">
+                    <a href="https://github.com/jeremylongshore/iam-bob-adk" class="btn btn-primary" target="_blank" rel="noopener">
                         View Source on GitHub
                     </a>
-                    <a href="https://github.com/jeremylongshore/bobs-brain/tree/main/000-docs" class="btn btn-secondary" target="_blank" rel="noopener">
+                    <a href="https://github.com/jeremylongshore/iam-bob-adk/tree/main/000-docs" class="btn btn-secondary" target="_blank" rel="noopener">
                         Browse Documentation
                     </a>
                 </div>
@@ -358,17 +358,17 @@ graph TD
                             <h4>📖 Core Documentation</h4>
                             <ul class="link-list">
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/blob/main/README.md" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/blob/main/README.md" target="_blank" rel="noopener">
                                         README - Project Overview
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/blob/main/CLAUDE.md" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/blob/main/CLAUDE.md" target="_blank" rel="noopener">
                                         CLAUDE.md - Architecture Details
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/blob/main/CHANGELOG.md" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/blob/main/CHANGELOG.md" target="_blank" rel="noopener">
                                         CHANGELOG - Version History
                                     </a>
                                 </li>
@@ -378,17 +378,17 @@ graph TD
                             <h4>📚 000-docs/ Archive</h4>
                             <ul class="link-list">
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/tree/main/000-docs" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/tree/main/000-docs" target="_blank" rel="noopener">
                                         Browse All Documentation (79+ docs)
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/blob/main/000-docs/120-AA-AUDT-appaudit-devops-playbook.md" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/blob/main/000-docs/120-AA-AUDT-appaudit-devops-playbook.md" target="_blank" rel="noopener">
                                         DevOps Playbook
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/blob/main/000-docs/121-DR-GUIDE-live3-dev-smoke-test.md" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/blob/main/000-docs/121-DR-GUIDE-live3-dev-smoke-test.md" target="_blank" rel="noopener">
                                         LIVE3 Smoke Test Guide
                                     </a>
                                 </li>
@@ -398,17 +398,17 @@ graph TD
                             <h4>🚀 Get Started</h4>
                             <ul class="link-list">
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk" target="_blank" rel="noopener">
                                         View Repository on GitHub
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/issues" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/issues" target="_blank" rel="noopener">
                                         Report Issues or Feedback
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://github.com/jeremylongshore/bobs-brain/blob/main/LICENSE" target="_blank" rel="noopener">
+                                    <a href="https://github.com/jeremylongshore/iam-bob-adk/blob/main/LICENSE" target="_blank" rel="noopener">
                                         MIT License
                                     </a>
                                 </li>
@@ -427,7 +427,7 @@ graph TD
             <p>
                 Built by <a href="https://intentsolutions.io" target="_blank" rel="noopener">Intent Solutions</a>
                 ·
-                <a href="https://github.com/jeremylongshore/bobs-brain" target="_blank" rel="noopener">jeremylongshore/bobs-brain</a>
+                <a href="https://github.com/jeremylongshore/iam-bob-adk" target="_blank" rel="noopener">jeremylongshore/iam-bob-adk</a>
             </p>
             <p class="footer-meta">
                 Version 0.9.0 · Last updated November 2025 · Open source under MIT License

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ This file defines test sessions for running pytest across multiple Python versio
 linting, type checking, and MCP-specific tests. Follows Google Analytics MCP patterns.
 
 Sessions:
-- tests: Run pytest on Python 3.10, 3.11, 3.12, 3.13
+- tests: Run pytest on Python 3.11, 3.12, 3.13
 - lint: Run ruff and black checks
 - typecheck: Run mypy on agents/ and mcp/
 - tests_mcp: Run MCP-specific tests
@@ -33,7 +33,7 @@ nox.options.reuse_existing_virtualenvs = True
 nox.options.error_on_external_run = False
 
 # Python versions to test (aligned with ADK requirements)
-PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
+PYTHON_VERSIONS = ["3.11", "3.12", "3.13"]
 DEFAULT_PYTHON = "3.12"  # Bob's Brain currently uses Python 3.12
 
 
@@ -163,6 +163,7 @@ def tests_mcp(session):
 
     # Check if mcp/ directory exists
     import os
+
     if os.path.exists("mcp/"):
         session.run(
             "pytest",
@@ -416,7 +417,8 @@ def arv(session):
     session.run(
         "python",
         "scripts/run_arv_department.py",
-        "--env", "dev",
+        "--env",
+        "dev",
         *session.posargs,
     )
 
@@ -462,7 +464,8 @@ def tests_e2e(session):
         "-v",
         "--color=yes",
         "--tb=long",
-        "-m", "e2e",
+        "-m",
+        "e2e",
         *session.posargs,
     )
 
@@ -488,7 +491,8 @@ def tests_smoke(session):
         "-v",
         "--color=yes",
         "--tb=short",
-        "-m", "smoke",
+        "-m",
+        "smoke",
         *session.posargs,
     )
 
@@ -514,7 +518,8 @@ def tests_contract(session):
         "-v",
         "--color=yes",
         "--tb=short",
-        "-m", "contract",
+        "-m",
+        "contract",
         *session.posargs,
     )
 
@@ -536,8 +541,8 @@ def clean(session):
     """
     session.log("Cleaning up generated files and caches")
 
-    import shutil
     import pathlib
+    import shutil
 
     patterns = [
         "**/__pycache__",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 # Bob's Brain - Python Dependencies
 # Hard Mode: ADK + Agent Engine only (R1, R2)
-# Last Updated: 2025-11-11
+# Last Updated: 2026-07-15
 
 # Core ADK (R1: Agent implementation framework)
-google-adk>=1.18.0,<1.19.0  # Pinned to 1.18.x (google-adk 1.18+ API)
+google-adk>=2.4.0,<2.5.0  # Patched ADK line; preserves the official Google runtime
+starlette>=1.3.1,<2.0.0  # Security floor for the ADK/FastAPI HTTP stack
+setuptools>=83.0.0  # Security floor for build/runtime package metadata
 
 # A2A Protocol (R7: Agent-to-Agent communication)
 a2a-sdk>=0.3.0

--- a/service/a2a_gateway/main.py
+++ b/service/a2a_gateway/main.py
@@ -15,6 +15,7 @@ Environment Variables:
 - LOCATION: GCP region
 - AGENT_ENGINE_ID: Agent Engine instance ID
 - PORT: Service port (default 8080)
+- BIND_HOST: Direct-execution bind host (default 127.0.0.1; containers set theirs)
 """
 
 import logging
@@ -37,6 +38,7 @@ PROJECT_ID = os.getenv("PROJECT_ID")
 LOCATION = os.getenv("LOCATION")
 AGENT_ENGINE_ID = os.getenv("AGENT_ENGINE_ID")
 PORT = int(os.getenv("PORT", "8080"))
+BIND_HOST = os.getenv("BIND_HOST", "127.0.0.1")
 
 # Agent Engine REST API endpoint
 # Format: https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/reasoningEngines/{AGENT_ENGINE_ID}:query
@@ -436,4 +438,4 @@ if __name__ == "__main__":
         },
     )
 
-    uvicorn.run(app, host="0.0.0.0", port=PORT, log_level="info")
+    uvicorn.run(app, host=BIND_HOST, port=PORT, log_level="info")

--- a/service/github_webhook/main.py
+++ b/service/github_webhook/main.py
@@ -20,6 +20,7 @@ Environment Variables:
 - PROJECT_ID: GCP project ID
 - DEPLOYMENT_ENV: Deployment environment (dev/prod)
 - PORT: Service port (default 8080)
+- BIND_HOST: Direct-execution bind host (default 127.0.0.1; containers set theirs)
 
 Phase H: Universal Autonomous AI Crew - Event Triggers
 """
@@ -46,6 +47,7 @@ A2A_GATEWAY_URL = os.getenv("A2A_GATEWAY_URL")
 PROJECT_ID = os.getenv("PROJECT_ID")
 DEPLOYMENT_ENV = os.getenv("DEPLOYMENT_ENV", "dev")
 PORT = int(os.getenv("PORT", "8080"))
+BIND_HOST = os.getenv("BIND_HOST", "127.0.0.1")
 
 
 # Validate required environment variables
@@ -474,4 +476,4 @@ if __name__ == "__main__":
         },
     )
 
-    uvicorn.run(app, host="0.0.0.0", port=PORT, log_level="info")
+    uvicorn.run(app, host=BIND_HOST, port=PORT, log_level="info")

--- a/service/slack_webhook/main.py
+++ b/service/slack_webhook/main.py
@@ -17,6 +17,7 @@ Environment Variables:
 - LOCATION: GCP region
 - AGENT_ENGINE_ID: Agent Engine instance ID
 - PORT: Service port (default 8080)
+- BIND_HOST: Direct-execution bind host (default 127.0.0.1; containers set theirs)
 - SLACK_SWE_PIPELINE_MODE: Routing mode (local|engine) - Phase AE2
 - A2A_GATEWAY_URL: A2A gateway URL (for engine mode) - Phase AE2
 """
@@ -45,6 +46,7 @@ PROJECT_ID = os.getenv("PROJECT_ID")
 LOCATION = os.getenv("LOCATION")
 AGENT_ENGINE_ID = os.getenv("AGENT_ENGINE_ID")
 PORT = int(os.getenv("PORT", "8080"))
+BIND_HOST = os.getenv("BIND_HOST", "127.0.0.1")
 
 # A2A Gateway URL (SLACK-ENDTOEND-DEV: S2)
 # Preferred routing: Slack → a2a_gateway → Agent Engine
@@ -463,4 +465,4 @@ if __name__ == "__main__":
         },
     )
 
-    uvicorn.run(app, host="0.0.0.0", port=PORT, log_level="info")
+    uvicorn.run(app, host=BIND_HOST, port=PORT, log_level="info")

--- a/tests/unit/test_arv_check_impl.py
+++ b/tests/unit/test_arv_check_impl.py
@@ -1,0 +1,44 @@
+"""Security and execution tests for ARV checks."""
+
+from pathlib import Path
+
+from agents.arv.check_impl import run_check
+from agents.arv.spec import ArvCheck
+
+
+def _check(command: str) -> ArvCheck:
+    return ArvCheck(
+        id="test-command",
+        description="Test command execution",
+        category="tests",
+        required=True,
+        command=command,
+    )
+
+
+def test_run_check_executes_argument_vector() -> None:
+    result = run_check(_check("python3 -c 'print(\"ready\")'"), "dev", verbose=True)
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert result.details == "ready\n"
+
+
+def test_run_check_does_not_interpret_shell_operators(tmp_path: Path) -> None:
+    marker = tmp_path / "shell-was-used"
+    command = f"python3 -c 'print(\"safe\")' ; touch {marker}"
+
+    result = run_check(_check(command), "dev")
+
+    assert result.passed is True
+    assert not marker.exists()
+
+
+def test_run_check_rejects_empty_command() -> None:
+    result = run_check(_check(""), "dev")
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert (
+        result.details == "Error executing check: ARV check command must not be empty"
+    )


### PR DESCRIPTION
## What changed

- normalizes current README clone/resource links to jeremylongshore/iam-bob-adk
- updates the CI badge, active A2A documentation pointers, agent docs, Slack project link, and GitHub Pages links
- preserves Google project names, SPIFFE IDs, GCS prefixes, container names, Agent Engine names, and archived evidence

## Why

The GitHub repository was already renamed, but active operator and agent-facing references still pointed at prior repository names. This is the scoped post-rename reconciliation for the preserved Google ADK implementation of the Intent Agent Model.

## Validation

- scripts/ci/check_nodrift.sh
- make check-a2a-contracts (10/10 AgentCards)
- JSON parsing of representative active cards
- git diff --check

## Known baseline issue

The existing main security job is already red from two Bandit findings and dependency advisories. This rename-only PR does not conceal or waive that unrelated baseline failure.
